### PR TITLE
feat: add support for deploying wasm app from GitHub repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,36 @@ Upload `main.wasm` to a bucket for download and then run the container providing
   wasm-runner:local
 ```
 
+Alternatively, provide a GitHub repository URL containing a `.wasm` file:
+
+```
+% docker run --rm \
+  -p 8080:8080 \
+  -e GITHUB_URL=https://github.com/<org>/<repo>/ \
+  wasm-runner:local
+```
+
+For private repositories, provide a GitHub personal access token:
+
+```
+% docker run --rm \
+  -p 8080:8080 \
+  -e GITHUB_URL=https://github.com/<org>/<repo>/ \
+  -e GITHUB_TOKEN=<token> \
+  wasm-runner:local
+```
+
+You can specify a branch using a URL fragment:
+
+```
+% docker run --rm \
+  -p 8080:8080 \
+  -e GITHUB_URL=https://github.com/<org>/<repo>#<branch> \
+  wasm-runner:local
+```
+
+The entrypoint will clone the repository, find the first `.wasm` file, and run it. The WASM module is expected to follow the [WASI](https://wasi.dev/) convention and export a `_start` entry point (the default for `wasmedge`).
+
 The WASM application `main.wasm` can now be invoked through the HTTP server on port 8080. Provides these endpoints:
 
 | Method | Path | Description |

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,15 +1,57 @@
 #!/bin/bash
 
-if [ -z "$WASM_URL" ]; then
-  echo "WASM_URL is not set. Exiting."
+if [ -z "$WASM_URL" ] && [ -z "$GITHUB_URL" ]; then
+  echo "WASM_URL or GITHUB_URL must be set. Exiting."
   exit 1
+fi
+
+if [[ ! -z "$WASM_URL" ]] && [[ "$WASM_URL" =~ ^https?://github\.com/ ]]; then
+  GITHUB_URL="$WASM_URL"
+  unset WASM_URL
 fi
 
 STAGING_DIR="/usercontent"
 echo "ensure staging dir is empty"
-rm -rf /usercontent/*
-echo "Downloading WASM file from $WASM_URL"
-curl -sSL "$WASM_URL" -o /usercontent/main.wasm
+rm -rf /usercontent/* /usercontent/.[!.]*
+
+if [[ ! -z "$GITHUB_URL" ]]; then
+  branch=""
+  if [[ "$GITHUB_URL" == *"#"* ]]; then
+    branch="${GITHUB_URL#*#}"
+    branch="${branch%/}"
+    GITHUB_URL="${GITHUB_URL%%#*}"
+  fi
+
+  path="/${GITHUB_URL#*://*/}" && [[ "/${GITHUB_URL}" == "${path}" ]] && path="/"
+
+  if [[ ! -z "$GITHUB_TOKEN" ]]; then
+    echo "cloning https://***@github.com${path}"
+    git clone https://$GITHUB_TOKEN@github.com${path} /usercontent/
+  else
+    echo "cloning https://github.com${path}"
+    git clone https://github.com${path} /usercontent/
+  fi
+
+  git config --global --add safe.directory /usercontent
+  if [[ ! -z "$branch" ]]; then
+    echo "checking out branch: $branch"
+    git -C /usercontent/ checkout "$branch"
+  fi
+
+  # Find .wasm file in repo (WASI _start entry point is called by wasmedge by default)
+  WASM_FILE=$(find /usercontent -name "*.wasm" -type f ! -path "/usercontent/.git/*" | head -1)
+  if [ -z "$WASM_FILE" ]; then
+    echo "No .wasm file found in repository. Exiting."
+    exit 1
+  fi
+  echo "Found WASM file: $WASM_FILE"
+  if [ "$WASM_FILE" != "/usercontent/main.wasm" ]; then
+    cp "$WASM_FILE" /usercontent/main.wasm
+  fi
+elif [[ ! -z "$WASM_URL" ]]; then
+  echo "Downloading WASM file from $WASM_URL"
+  curl -sSL "$WASM_URL" -o /usercontent/main.wasm
+fi
 
 chown runner:runner -R /usercontent
 cd /usercontent


### PR DESCRIPTION
## Summary
- Add `GITHUB_URL` and `GITHUB_TOKEN` environment variables as an alternative to `WASM_URL` for deploying WASM apps directly from a GitHub repository
- Support branch selection via URL fragment (e.g. `https://github.com/org/repo#branch`)
- Auto-detect GitHub URLs passed via `WASM_URL` and handle them as repo clones
- Entrypoint clones the repo, finds the first `.wasm` file, and runs it using the WASI `_start` convention (default for wasmedge)

## Test plan
- [ ] Verify `WASM_URL` with a direct .wasm file URL still works as before
- [ ] Test `GITHUB_URL` with a public repo containing a .wasm file
- [ ] Test `GITHUB_URL` + `GITHUB_TOKEN` with a private repo
- [ ] Test branch selection with `GITHUB_URL=https://github.com/org/repo#branch`
- [ ] Verify a GitHub URL passed via `WASM_URL` is auto-detected and cloned

🤖 Generated with [Claude Code](https://claude.com/claude-code)