### PR TITLE
fix: scrub PAT from git origin remote after clone

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -69,6 +69,8 @@ if [[ ! -z "$GIT_URL" ]]; then
     echo "cloning https://${GIT_HOST}${path}"
     git clone "https://${GIT_HOST}${path}" /usercontent/
   fi
+  # Scrub PAT from origin remote — token must not persist to .git/config
+  git -C /usercontent/ remote set-url origin "https://${GIT_HOST}${path}"
 
   git config --global --add safe.directory /usercontent
   if [[ ! -z "$branch" ]]; then


### PR DESCRIPTION
## Summary

After a successful git clone with a token-embedded URL, the token is stored persistently in `.git/config`. This PR adds a `git remote set-url` call immediately after every clone to strip the credentials from the stored origin URL.

## Change

In `scripts/docker-entrypoint.sh`, after the clone block:
\`\`\`bash
# Scrub PAT from origin remote — token must not persist to .git/config
git -C /usercontent/ remote set-url origin "https://\${GIT_HOST}\${path}"
\`\`\`

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/code)